### PR TITLE
Fixed bug with bin/phar-package.php

### DIFF
--- a/bin/phar-package.php
+++ b/bin/phar-package.php
@@ -15,7 +15,7 @@ $phar_name = "$project_name.phar";
 $phar = new Phar("../$phar_name", 0, $phar_name);
 
 foreach ($package_data->contents->dir->file as $file)
-    $phar->addFile(realpath("../{$file['name']}"));
+    $phar->addFile(realpath("../{$file['name']}"), $file['baseinstalldir'] . $file['install-as']);
 
 $phar->addFromString("autoload.php", <<<'LOADER'
 <?php


### PR DESCRIPTION
Running make phar would result in a Phar archive with files being referenced
by the whole path /path/to/Respect/Rest/file.php rather than /Respect/Rest/file.php. This was breaking the autoloading mechanism.

I've fixed this by adding in an alias using the baseinstallpath and install-as to create the correct filename for inclusion in the archive.
