### PR TITLE
publish router's and route's methods via phpdoc @method

### DIFF
--- a/library/Respect/Rest/Router.php
+++ b/library/Respect/Rest/Router.php
@@ -11,6 +11,14 @@ use Respect\Rest\Routes;
 use Respect\Rest\Routes\AbstractRoute;
 use Respect\Rest\Exception\MethodNotAllowed;
 
+/**
+ * @method \Respect\Rest\Routes\AbstractRoute get(string $path, $routeTarget)
+ * @method \Respect\Rest\Routes\AbstractRoute post(string $path, $routeTarget)
+ * @method \Respect\Rest\Routes\AbstractRoute put(string $path, $routeTarget)
+ * @method \Respect\Rest\Routes\AbstractRoute head(string $path, $routeTarget)
+ * @method \Respect\Rest\Routes\AbstractRoute delete(string $path, $routeTarget)
+ * @method \Respect\Rest\Routes\AbstractRoute any(string $path, $routeTarget)
+ */
 class Router
 {
 

--- a/library/Respect/Rest/Routes/AbstractRoute.php
+++ b/library/Respect/Rest/Routes/AbstractRoute.php
@@ -10,7 +10,32 @@ use Respect\Rest\Routines\IgnorableFileExtension;
 use Respect\Rest\Routines\Unique;
 use Respect\Rest\Exception\MethodNotAllowed;
 
-/** Base class for all Routes */
+/**
+ * Base class for all Routes
+ *
+ * @method \Respect\Rest\Routes\AbstractRoute abstractAccept()
+ * @method \Respect\Rest\Routes\AbstractRoute abstractRoutine()
+ * @method \Respect\Rest\Routes\AbstractRoute abstractSyncedRoutine()
+ * @method \Respect\Rest\Routes\AbstractRoute acceptCharset()
+ * @method \Respect\Rest\Routes\AbstractRoute acceptEncoding()
+ * @method \Respect\Rest\Routes\AbstractRoute acceptLanguage()
+ * @method \Respect\Rest\Routes\AbstractRoute accept()
+ * @method \Respect\Rest\Routes\AbstractRoute authBasic()
+ * @method \Respect\Rest\Routes\AbstractRoute by()
+ * @method \Respect\Rest\Routes\AbstractRoute contentType()
+ * @method \Respect\Rest\Routes\AbstractRoute ignorableFileExtension()
+ * @method \Respect\Rest\Routes\AbstractRoute lastModified()
+ * @method \Respect\Rest\Routes\AbstractRoute paramSynced()
+ * @method \Respect\Rest\Routes\AbstractRoute proxyableBy()
+ * @method \Respect\Rest\Routes\AbstractRoute proxyableThrough()
+ * @method \Respect\Rest\Routes\AbstractRoute proxyableWhen()
+ * @method \Respect\Rest\Routes\AbstractRoute routinable()
+ * @method \Respect\Rest\Routes\AbstractRoute through()
+ * @method \Respect\Rest\Routes\AbstractRoute unique()
+ * @method \Respect\Rest\Routes\AbstractRoute userAgent()
+ * @method \Respect\Rest\Routes\AbstractRoute when()
+ * ...
+ */
 abstract class AbstractRoute
 {
     const CATCHALL_IDENTIFIER = '/**';


### PR DESCRIPTION
The Router and Routes leave IDEs clueless about their most used methods. This commit adds phpdoc tags for those methods.
