### PR TITLE
Set 401 and WWW-Authenticate when authBasic() returns false

### DIFF
--- a/library/Respect/Rest/Routines/AuthBasic.php
+++ b/library/Respect/Rest/Routines/AuthBasic.php
@@ -17,19 +17,25 @@ class AuthBasic extends AbstractRoutine implements ProxyableBy
 
 	public function by(Request $request, $params)
 	{
+		$callbackResponse = false;
+
 		if (isset($_SERVER['HTTP_AUTHORIZATION']))
-			return call_user_func_array(
+			$callbackResponse = call_user_func_array(
 				$this->callback,
 				array_merge(explode(':', base64_decode(substr($_SERVER['HTTP_AUTHORIZATION'], 6))), $params)
 			);
 		elseif (isset($_SERVER['PHP_AUTH_USER']))
-                       return call_user_func_array(
+                       $callbackResponse = call_user_func_array(
                                $this->callback,
                                array_merge(array($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']), $params));
 
-		header('HTTP/1.1 401');
-		header("WWW-Authenticate: Basic realm=\"{$this->realm}\"");
-		return call_user_func($this->callback, null, null);
+		if ($callbackResponse === false) {
+			header('HTTP/1.1 401');
+			header("WWW-Authenticate: Basic realm=\"{$this->realm}\"");
+			return call_user_func($this->callback, null, null);
+		}
+
+		return $callbackResponse;
 	}
 
 }

--- a/tests/library/Respect/Rest/RouterTest.php
+++ b/tests/library/Respect/Rest/RouterTest.php
@@ -348,6 +348,25 @@ namespace Respect\Rest {
 
         /**
          * @group issues
+         * @ticket 49
+         */
+        function test_http_auth_should_send_401_and_WWW_headers_when_authBasic_returns_false()
+        {
+            global $header;
+            $user = 'John';
+            $pass = 'Doe';
+            $_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode($user.':'.$pass);
+            $this->router->get('/', 'ok')->authBasic('Test Realm', function($username, $password) {
+                return (($username == 'user') && ($password == 'pass'));
+            });
+            (string) $this->router->dispatch('GET', '/')->response();
+            $this->assertContains('HTTP/1.1 401', $header);
+            $this->assertContains('WWW-Authenticate: Basic realm="Test Realm"', $header);
+            unset($_SERVER['HTTP_AUTHORIZATION']);
+        }
+
+        /**
+         * @group issues
          * @ticket 37
         **/
         function test_optional_parameter_in_class_routes(){


### PR DESCRIPTION
See discussion on Issue #49 for background on why I am sending this pull request.

Previously, if authBasic() returned false (possibly due to invalid credentials), a 200 OK was returned, even though the restricted content was not being returned. This pull request modifies this behavior such that a 401 with a WWW-Authenticate header is returned instead.
