### PR TITLE
Adding in support for multiple routes definitions through an array

### DIFF
--- a/library/Respect/Rest/Router.php
+++ b/library/Respect/Rest/Router.php
@@ -145,6 +145,14 @@ class Router
 
         list ($path, $routeTarget) = $args;
 
+         // Support multiple route definitions as array of paths
+        if (is_array($path)) {
+            $lastPath = array_pop($path);
+            foreach ($path as $p)
+                 $this->$method($p, $routeTarget);
+             return $this->$method($lastPath, $routeTarget);
+        }
+       
         //closures, func names, callbacks
         if (is_callable($routeTarget)) {
 


### PR DESCRIPTION
Feature discussed in issue #89

Thanks @nickl- for supplying the code

This addition would allow you to define multiple paths to the same routine. This would be useful in cases when you want to pluralize.

```
$r3->any(array('/User', '/Users'), function(){
     return 'Hello World';
});
```
