### PR TITLE
Update ClassName.php

### DIFF
--- a/library/Respect/Rest/Routes/ClassName.php
+++ b/library/Respect/Rest/Routes/ClassName.php
@@ -103,10 +103,15 @@ class ClassName extends AbstractRoute
             $this->instance = $this->createInstance();
         }
 
-        return call_user_func_array(
-            array($this->instance, $method), 
-            $params
-        );
+		if(method_exists($this->instance, $method ) ){
+			return call_user_func_array(
+				array($this->instance, $method), $params
+			);
+		} else {
+			return call_user_func_array(
+				array($this->instance, 'notimplemented'), $params
+			);
+		}
     }
 
 }


### PR DESCRIPTION
Error when calling an HTTP method that doesn't exists in the instance of the class. It is called a 'nonimplemented' method of the class.
