### PR TITLE
Allow Respect\Rest\Router as target.

### DIFF
--- a/library/Respect/Rest/Router.php
+++ b/library/Respect/Rest/Router.php
@@ -174,6 +174,9 @@ class Router
         } elseif ($routeTarget instanceof Routable) {
             return $this->instanceRoute($method, $path, $routeTarget);
 
+        } elseif ($routeTarget instanceof Router) {
+            return $this->instanceSubRouter($method, $path, $routeTarget);
+
         //static returns the argument itself
         } elseif (!is_string($routeTarget)) {
             return $this->staticRoute($method, $path, $routeTarget);
@@ -474,6 +477,24 @@ class Router
     public function instanceRoute($method, $path, $instance)
     {
         $route = new Routes\Instance($method, $path, $instance);
+        $this->appendRoute($route);
+
+        return $route;
+    }
+
+
+    /**
+     * Creates and returns an router-based route
+     *
+     * @param string $method  The HTTP metod (GET, POST, etc)
+     * @param string $path    The URI Path (/foo/bar...)
+     * @param string $intance An instance of Router
+     *
+     * @return Respect\Rest\Routes\SubRouter The route created
+     */
+    public function instanceSubRouter($method, $path, $instance)
+    {
+        $route = new Routes\SubRouter($method, $path, $instance);
         $this->appendRoute($route);
 
         return $route;

--- a/library/Respect/Rest/Routes/SubRouter.php
+++ b/library/Respect/Rest/Routes/SubRouter.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * This file is part of the Respect\Rest package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Rest\Routes;
+
+use ReflectionMethod;
+use InvalidArgumentException;
+use Respect\Rest\Router;
+use Respect\Rest\Request;
+
+class SubRouter extends AbstractRoute
+{
+    protected $uri = null;
+    protected $instance = null;
+    /** @var ReflectionMethod */
+    protected $reflection;
+
+    public function __construct($method, $pattern, $instance)
+    {
+        $this->instance = $instance;
+        parent::__construct($method, $pattern);
+    }
+
+    public function getReflection($method)
+    {
+        if (empty($this->reflection)) {
+            $this->reflection = new ReflectionMethod(
+                $this->instance,
+                $method
+            );
+        }
+
+        return $this->reflection;
+    }
+
+    public function match(Request $request, &$params = array()){
+       #Store the request
+       $this->uri = $request->uri;
+       $params=array();
+       if(preg_match("#^".$this->pattern."#", $request->uri)){
+          $this->uri = preg_replace("#^".$this->pattern."#", '', $this->uri);
+          return true;
+       }
+       return false;
+    }
+
+    public function runTarget($method, &$params)
+    {
+        if (!$this->instance instanceof Router) {
+            throw new InvalidArgumentException('Route target must be an instance of Respect\Rest\Router');
+        }
+
+        return (string)$this->instance->run(new Request($method, $this->uri));
+    }
+}


### PR DESCRIPTION
Allow to define a Router as target which allows nesting of
several indipendent router. This makes routers reuseable.

See #119.