### PR TITLE
Fixes bug where OPTIONS req. calls other handlers

### DIFF
--- a/library/Respect/Rest/Router.php
+++ b/library/Respect/Rest/Router.php
@@ -537,7 +537,7 @@ class Router
 
         //OPTIONS? Let's inform the allowd methods
         if ($this->request->method === 'OPTIONS' && $allowedMethods) {
-            header('Allow: '.implode(', ', $allowedMethods));
+            $this->handleOptionsRequest($allowedMethods, $matchedByPath);
         } elseif (0 === count($matchedByPath)) {
             header('HTTP/1.1 404');
         } elseif (!$this->routineMatch($matchedByPath) instanceof Request) {
@@ -675,6 +675,26 @@ class Router
 
         $this->informAllowedMethods($allowedMethods);
         $this->request->route = null;
+    }
+
+    /**
+     * Handles a OPTIONS request, inform of the allowed methods and
+     * calls custom OPTIONS handler (if any).
+     *
+     * @param array $allowedMehods A list of allowed methods
+     * @param \SplObjectStorage $matchedByPath A list of matched routes by path
+     *
+     * @return null sends Allow header.
+     */
+    protected function handleOptionsRequest(array $allowedMethods, \SplObjectStorage $matchedByPath)
+    {
+        $this->informAllowedMethods($allowedMethods);
+
+        if (in_array('OPTIONS', $allowedMethods)) {
+            $this->routineMatch($matchedByPath);
+        } else {
+            $this->request->route = null;
+        }
     }
 
     /**

--- a/tests/library/Respect/Rest/RouterTest.php
+++ b/tests/library/Respect/Rest/RouterTest.php
@@ -437,6 +437,62 @@ class RouterTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @covers Respect\Rest\Router::handleOptionsRequest
+     * @runInSeparateProcess
+     */
+    public function testOptionsRequestShouldNotCallOtherHandlers()
+    {
+        // arrange
+        $router = new Router;
+        $router->get('/asian', 'GET: Asian Food!');
+        $router->post('/asian', 'POST: Asian Food!');
+
+        // act
+        $response = (string) $router->dispatch('OPTIONS', '/asian')->response();
+
+        // assert
+        $this->assertContains(
+            'Allow: GET, POST',
+            xdebug_get_headers(),
+            'There should be a sent Allow header with all methods for the handler that match this request.'
+        );
+
+        $this->assertEquals(
+            '',
+            $response,
+            'OPTIONS request should never call any of the other registered handlers.'
+        );
+    }
+
+    /**
+     * @covers Respect\Rest\Router::handleOptionsRequest
+     * @runInSeparateProcess
+     */
+    public function testOptionsRequestShouldBeDispatchedToCorrectOptionsHandler()
+    {
+        // arrange
+        $router = new Router;
+        $router->get('/asian', 'GET: Asian Food!');
+        $router->options('/asian', 'OPTIONS: Asian Food!');
+        $router->post('/asian', 'POST: Asian Food!');
+
+        // act
+        $response = (string) $router->dispatch('OPTIONS', '/asian')->response();
+
+        // assert
+        $this->assertContains(
+            'Allow: GET, OPTIONS, POST',
+            xdebug_get_headers(),
+            'There should be a sent Allow header with all methods for the handler that match this request.'
+        );
+
+        $this->assertEquals(
+            'OPTIONS: Asian Food!',
+            $response,
+            'OPTIONS request should call the correct custom OPTIONS handler.'
+        );
+    }
 }
 
 if (!function_exists(__NAMESPACE__.'\\header')) {


### PR DESCRIPTION
This commit fixes a bug where OPTIONS requests would, in addtion
to set the correct 'Allow' header, call a route that matches on
path, but not on method. More specifically the last handler that
matches on the path.

The commit also makes sure that custom OPTIONS handlers are called.
So if an application now registers an '->options' handler the correct
'Allow' header is set then the custom OPTIONS handler is called.

fixes #122 