### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4.0"
+        "phpunit/phpunit": "~4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/tests/legacy/Respect/Rest/OldRouterTest.php
+++ b/tests/legacy/Respect/Rest/OldRouterTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Respect\Rest {
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Router
  * @covers Respect\Rest\Request
@@ -35,7 +37,7 @@ namespace Respect\Rest {
  * @covers Respect\Rest\Routines\UserAgent
  * @covers Respect\Rest\Routines\When
  */
-class OldRouterTest extends \PHPUnit_Framework_TestCase
+class OldRouterTest extends TestCase
 {
 
     protected $object;

--- a/tests/legacy/Respect/Rest/RequestTest.php
+++ b/tests/legacy/Respect/Rest/RequestTest.php
@@ -2,12 +2,14 @@
 
 namespace Respect\Rest;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Request
  */
-class LegacyRequestTest extends \PHPUnit_Framework_TestCase
+class LegacyRequestTest extends TestCase
 {
-    function setUp() 
+    function setUp()
     {
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP';
         $_SERVER['REQUEST_URI'] = '/';

--- a/tests/legacy/Respect/Rest/RouterTest.php
+++ b/tests/legacy/Respect/Rest/RouterTest.php
@@ -2,6 +2,8 @@
 
 namespace Respect\Rest {
 
+    use PHPUnit\Framework\TestCase;
+
     class DummyRoute extends \DateTime implements Routable {}
     /**
      * @covers Respect\Rest\Router
@@ -38,7 +40,7 @@ namespace Respect\Rest {
      * @covers Respect\Rest\Routines\UserAgent
      * @covers Respect\Rest\Routines\When
      */
-    class NewRouterTest extends \PHPUnit_Framework_TestCase
+    class NewRouterTest extends TestCase
     {
         function setUp()
         {
@@ -575,7 +577,7 @@ namespace Respect\Rest {
             $this->assertEquals('"ok: blub"', $out);
 
         }
-        
+
         function test_request_should_be_available_from_router_after_dispatching()
         {
             $request = new \Respect\Rest\Request('get', '/foo');

--- a/tests/legacy/Respect/Rest/Routes/AbstractRouteTest.php
+++ b/tests/legacy/Respect/Rest/Routes/AbstractRouteTest.php
@@ -2,11 +2,13 @@
 namespace Respect\Rest\Routes {
 
 use Respect\Rest\Router;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Routes\AbstractRoute
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class AbstractRouteTest extends \PHPUnit_Framework_TestCase
+class AbstractRouteTest extends TestCase
 {
     /**
      * @var AbstractRoute local instance

--- a/tests/legacy/Respect/Rest/Routes/ClassNameTest.php
+++ b/tests/legacy/Respect/Rest/Routes/ClassNameTest.php
@@ -2,10 +2,12 @@
 
 namespace Respect\Rest\Routes;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Routes\ClassName
  */
-class ClassNameTest extends \PHPUnit_Framework_TestCase
+class ClassNameTest extends TestCase
 {
     function setUp()
     {

--- a/tests/legacy/Respect/Rest/Routes/FactoryTest.php
+++ b/tests/legacy/Respect/Rest/Routes/FactoryTest.php
@@ -3,13 +3,14 @@ namespace Respect\Rest\Routes;
 
 use \Respect\Rest\Routable;
 use \Respect\Rest\Router;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Respect\Rest\Routes\Factory
  */
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
-    function setUp() 
+    function setUp()
     {
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP';
         $_SERVER['REQUEST_URI'] = '/';

--- a/tests/legacy/Respect/Rest/Routes/InstanceTest.php
+++ b/tests/legacy/Respect/Rest/Routes/InstanceTest.php
@@ -2,12 +2,14 @@
 
 namespace Respect\Rest\Routes;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Routes\Instance
  */
-class InstanceTest extends \PHPUnit_Framework_TestCase
+class InstanceTest extends TestCase
 {
-    function setUp() 
+    function setUp()
     {
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP';
         $_SERVER['REQUEST_URI'] = '/';

--- a/tests/legacy/Respect/Rest/Routes/StaticValueTest.php
+++ b/tests/legacy/Respect/Rest/Routes/StaticValueTest.php
@@ -1,12 +1,14 @@
 <?php
 namespace Respect\Rest\Routes;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Routes\StaticValue
  */
-class StaticValueTest extends \PHPUnit_Framework_TestCase
+class StaticValueTest extends TestCase
 {
-    function setUp() 
+    function setUp()
     {
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP';
         $_SERVER['REQUEST_URI'] = '/';

--- a/tests/legacy/Respect/Rest/Routines/AbstractCallbackListTest.php
+++ b/tests/legacy/Respect/Rest/Routines/AbstractCallbackListTest.php
@@ -1,12 +1,13 @@
 <?php
 namespace Respect\Rest\Routines;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Respect\Rest\Routines\AbstractCallbackList
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class AbstractCallbackListTest extends \PHPUnit_Framework_TestCase
+class AbstractCallbackListTest extends TestCase
 {
     protected $object;
 
@@ -128,4 +129,3 @@ class FunkyAbstractCallbackList extends AbstractCallbackList{
         return $this->getCallback($key);
     }
 }
-

--- a/tests/legacy/Respect/Rest/Routines/AbstractCallbackMediatorTest.php
+++ b/tests/legacy/Respect/Rest/Routines/AbstractCallbackMediatorTest.php
@@ -3,12 +3,13 @@
 namespace Respect\Rest\Routines;
 
 use Respect\Rest\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Respect\Rest\Routines\AbstractCallbackMediator
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class AbstractCallbackMediatorTest extends \PHPUnit_Framework_TestCase
+class AbstractCallbackMediatorTest extends TestCase
 {
     /**
      * @var AbstractCallbackMediator
@@ -249,4 +250,3 @@ class Negotiator extends AbstractCallbackMediator {
     }
 
 }
-

--- a/tests/legacy/Respect/Rest/Routines/AbstractSyncedRoutineTest.php
+++ b/tests/legacy/Respect/Rest/Routines/AbstractSyncedRoutineTest.php
@@ -2,12 +2,13 @@
 namespace Respect\Rest\Routines;
 
 use Stubs\Routines\ByClassWithInvoke;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Respect\Rest\Routines\ParamSynced
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class AbstractSyncedRoutineTest extends \PHPUnit_Framework_TestCase
+class AbstractSyncedRoutineTest extends TestCase
 {
     /**
      * @var AbstractSyncedRoutine

--- a/tests/legacy/Respect/Rest/Routines/AuthBasicTest.php
+++ b/tests/legacy/Respect/Rest/Routines/AuthBasicTest.php
@@ -2,12 +2,13 @@
 
 namespace Respect\Rest\Routines {
 
+use Respect\Rest\Router;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Routines\AuthBasic
  */
-use Respect\Rest\Router;
-
-class AuthBasicTest extends \PHPUnit_Framework_TestCase {
+class AuthBasicTest extends TestCase {
 
     private static $wantedParams;
     private $router;

--- a/tests/legacy/Respect/Rest/Routines/ByTest.php
+++ b/tests/legacy/Respect/Rest/Routines/ByTest.php
@@ -4,12 +4,13 @@ namespace Respect\Rest\Routines;
 use Respect\Rest\Request,
     Respect\Rest\Router;
 use Stubs\Routines\ByClassWithInvoke;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Respect\Rest\Routines\By
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class ByTest extends \PHPUnit_Framework_TestCase
+class ByTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/legacy/Respect/Rest/Routines/ContentTypeTest.php
+++ b/tests/legacy/Respect/Rest/Routines/ContentTypeTest.php
@@ -2,11 +2,13 @@
 namespace Respect\Rest\Routines;
 
 use Respect\Rest\Request;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Routines\ContentType
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class ContentTypeTest extends \PHPUnit_Framework_TestCase
+class ContentTypeTest extends TestCase
 {
     /**
      * @var ContentType

--- a/tests/legacy/Respect/Rest/Routines/LastModifiedTest.php
+++ b/tests/legacy/Respect/Rest/Routines/LastModifiedTest.php
@@ -2,11 +2,13 @@
 namespace Respect\Rest\Routines {
 
 use Respect\Rest\Request;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Routines\LastModified
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class LastModifiedTest extends \PHPUnit_Framework_TestCase
+class LastModifiedTest extends TestCase
 {
     /**
      * @var LastModified

--- a/tests/legacy/Respect/Rest/Routines/ThroughTest.php
+++ b/tests/legacy/Respect/Rest/Routines/ThroughTest.php
@@ -2,12 +2,13 @@
 namespace Respect\Rest\Routines;
 
 use Respect\Rest\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Respect\Rest\Routines\Through
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class ThroughTest extends \PHPUnit_Framework_TestCase
+class ThroughTest extends TestCase
 {
     /**
      * @var Through

--- a/tests/legacy/Respect/Rest/Routines/UserAgentTest.php
+++ b/tests/legacy/Respect/Rest/Routines/UserAgentTest.php
@@ -2,11 +2,13 @@
 namespace Respect\Rest\Routines;
 
 use Respect\Rest\Request;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Respect\Rest\Routines\UserAgent
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class UserAgentTest extends \PHPUnit_Framework_TestCase
+class UserAgentTest extends TestCase
 {
     /**
      * @var UserAgent

--- a/tests/legacy/Respect/Rest/Routines/WhenTest.php
+++ b/tests/legacy/Respect/Rest/Routines/WhenTest.php
@@ -4,12 +4,13 @@ namespace Respect\Rest\Routines {
 use Respect\Rest\Request,
     Respect\Rest\Router;
 use Stubs\Routines\WhenAlwaysTrue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Respect\Rest\Routines\When
  * @author Nick Lombard <github@jigsoft.co.za>
  */
-class WhenTest extends \PHPUnit_Framework_TestCase
+class WhenTest extends TestCase
 {
     /**
      * @var When

--- a/tests/library/Respect/Rest/RequestTest.php
+++ b/tests/library/Respect/Rest/RequestTest.php
@@ -2,13 +2,13 @@
 namespace Respect\Rest;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
 
 /** 
  * @covers Respect\Rest\Request 
  */
-class RequestTest extends PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     /** 
      * @covers  Respect\Rest\Request::__construct

--- a/tests/library/Respect/Rest/RouterTest.php
+++ b/tests/library/Respect/Rest/RouterTest.php
@@ -1,11 +1,11 @@
 <?php
 namespace Respect\Rest;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 /**
  * @covers Respect\Rest\Router
  */
-class RouterTest extends PHPUnit_Framework_TestCase
+class RouterTest extends TestCase
 {
     public static $status = 200;
 

--- a/tests/library/Respect/Rest/Routes/ErrorTest.php
+++ b/tests/library/Respect/Rest/Routes/ErrorTest.php
@@ -1,13 +1,13 @@
 <?php
 namespace Respect\Rest\Routes;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Respect\Rest\Router;
 
 /** 
  * @covers Respect\Rest\Routes\Error
  */
-class ErrorTest extends PHPUnit_Framework_TestCase
+class ErrorTest extends TestCase
 {
     /**
      * @covers Respect\Rest\Routes\Error::getReflection

--- a/tests/library/Respect/Rest/Routes/ExceptionTest.php
+++ b/tests/library/Respect/Rest/Routes/ExceptionTest.php
@@ -1,13 +1,13 @@
 <?php
 namespace Respect\Rest\Routes;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Respect\Rest\Router;
 
 /** 
  * @covers Respect\Rest\Routes\Exception
  */
-class ExceptionTest extends PHPUnit_Framework_TestCase
+class ExceptionTest extends TestCase
 {
     /**
      * @covers Respect\Rest\Routes\Exception::getReflection

--- a/tests/library/Respect/Rest/Routines/AbstractRoutineTest.php
+++ b/tests/library/Respect/Rest/Routines/AbstractRoutineTest.php
@@ -3,13 +3,14 @@
 namespace Respect\Rest\Routines;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
 use ReflectionMethod;
 use Stubs\Routines\AbstractRoutine as Stub;
 use Stubs\Routines\WhenAlwaysTrue as InstanceWithInvoke;
 
 /** Test an AbstractRoutine (abstract class) instantiation through a stub class. */
-class AbstractRoutineTest extends \PHPUnit_Framework_TestCase
+class AbstractRoutineTest extends TestCase
 {
     /**
      * @dataProvider provide_valid_constructor_arguments

--- a/tests/library/Respect/Rest/Routines/RelTest.php
+++ b/tests/library/Respect/Rest/Routines/RelTest.php
@@ -2,13 +2,13 @@
 namespace Respect\Rest\Routines;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
 
 /** 
  * @covers Respect\Rest\Routines\Rel 
  */
-class RelTest extends PHPUnit_Framework_TestCase
+class RelTest extends TestCase
 {
 	public function testSimpleTextRelationPassesThroughData()
 	{

--- a/tests/library/Respect/Rest/Routines/WhenTest.php
+++ b/tests/library/Respect/Rest/Routines/WhenTest.php
@@ -2,13 +2,13 @@
 namespace Respect\Rest\Routines;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
 
 /** 
  * @covers Respect\Rest\Routines\When
  */
-class WhenTest2 extends PHPUnit_Framework_TestCase
+class WhenTest2 extends TestCase
 {
 	public function testRoutineWhenShouldBlockRouteFromMatchIfTheCallbackReturnIsFalse()
 	{


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.