### PR TITLE
fopen in binary mode

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -222,7 +222,7 @@ large files or wait for streams to finish before serving them.
 ```php
 $r3->get('/images/*/hi-res', function($imageName) {
     header('Content-type: image/jpg');
-    return fopen("/path/to/hi/images/{$imageName}.jpg", 'r');
+    return fopen("/path/to/hi/images/{$imageName}.jpg", 'rb');
 });
 ```
 
@@ -292,7 +292,7 @@ We highly recommend that you use a strong validation library when using this. Co
 ```php
 $r3->get('/images/*/hi-res', function($imageName) {
     header('Content-type: image/jpg');
-    return fopen("/path/to/hi/images/{$imageName}.jpg", 'r');
+    return fopen("/path/to/hi/images/{$imageName}.jpg", 'rb');
 })->when(function($imageName) {
     /** Using Respect Validation alias to `V` */
     return V::alphanum(".")->length(5,155)


### PR DESCRIPTION
some shitty OS's (for example MS Windows) may corrupt binary data like the sample .jpg files with fopen text mode, and the default fopen mode if none is specified, may be text mode (the only instances i can think of off-hand is MS Windows and classic MacOS, and PHP does not even support classic MacOS, but Windows is supported), quoting the docs:

> The default translation mode depends on the SAPI and version of PHP that you are using, so you are encouraged to always specify the appropriate flag for portability reasons. You should use the 't' mode if you are working with plain-text files and you use \n to delimit your line endings in your script, but expect your files to be readable with applications such as notepad. You should use the 'b' in all other cases.

so.. for Windows-portability reasons, one should pretty much always fopen in binary mode.